### PR TITLE
feat(renderer): nested groups outline level auto-calculation

### DIFF
--- a/Design/DslDefinition/DslDefinition_DetailDesign_v1.md
+++ b/Design/DslDefinition/DslDefinition_DetailDesign_v1.md
@@ -384,14 +384,18 @@ Area(name) = { topRow, bottomRow, leftCol, rightCol }
 
 ```xml
 <groups>
-  <groupRows at="DetailRows" collapsed="false"/>
-  <groupCols at="SomeCols"   collapsed="true"/>
+  <groupRows at="DetailRowsOuter" collapsed="false"/>
+  <groupRows at="DetailRowsInner" collapsed="true"/>
+  <groupCols at="SomeColsOuter"   collapsed="false"/>
+  <groupCols at="SomeColsInner"   collapsed="true"/>
 </groups>
 ```
 
 - 行グループ: `Area(name).topRow .. bottomRow` を対象。
 - 列グループ: `Area(name).leftCol .. rightCol` を対象。
-- `collapsed` が true の場合は Excel 側で折りたたんだ状態を指定。
+- ネストレベルは `groupRows/groupCols` の重なりから自動計算する（同じ行または列を覆うグループ数 = OutlineLevel）。
+- OutlineLevel は Excel 上限に合わせて `1..8` に丸める。
+- `collapsed` が true のグループに含まれる行/列は非表示にし、当該グループ終端に折りたたみマーカーを設定する。
 
 ### 7.4. autoFilter
 
@@ -635,3 +639,4 @@ DSL 本体と同じディレクトリに、スタイル専用ファイル `DslDe
 - `componentImport@href` も DSL ファイルから見た相対パス。
 - As-Is: 同名 component が複数存在する場合は「先勝ち + Issue(Error)」。
 - To-Be: 同名 component が複数存在する場合は「後勝ち + Warning」。
+

--- a/ExcelReport/ExcelReportLib.Tests/RendererTests.cs
+++ b/ExcelReport/ExcelReportLib.Tests/RendererTests.cs
@@ -397,6 +397,68 @@ public sealed class RendererTests
     }
 
     /// <summary>
+    /// Verifies that render nested row and column groups produce calculated outline levels.
+    /// </summary>
+    [Fact]
+    public void Render_NestedGroups_OutlineLevelsAreAutoCalculated()
+    {
+        var sheet = CreateWorksheet(
+            "Grouped",
+            cells:
+            [
+                CreateCell(1, 1, "Header"),
+            ],
+            options: new WorksheetOptionsState(
+                freezePanes: null,
+                rowGroups:
+                [
+                    new WorksheetGroupState("2:9", collapsed: false),
+                    new WorksheetGroupState("4:7", collapsed: true),
+                    new WorksheetGroupState("5:6", collapsed: false),
+                ],
+                columnGroups:
+                [
+                    new WorksheetGroupState("A:F", collapsed: false),
+                    new WorksheetGroupState("B:E", collapsed: true),
+                    new WorksheetGroupState("C:D", collapsed: false),
+                ],
+                autoFilter: null));
+
+        var renderer = CreateRenderer();
+        var result = renderer.Render([sheet], CreateOptions());
+
+        using var document = OpenWorkbook(result);
+        var worksheetPart = GetWorksheetPart(document, "Grouped");
+
+        var rows = worksheetPart.Worksheet.Descendants<Row>()
+            .Where(row => row.RowIndex is not null)
+            .ToDictionary(row => row.RowIndex!.Value);
+
+        Assert.Equal((byte)1, rows[2U].OutlineLevel!.Value);
+        Assert.Equal((byte)2, rows[4U].OutlineLevel!.Value);
+        Assert.Equal((byte)3, rows[5U].OutlineLevel!.Value);
+        Assert.Equal((byte)3, rows[6U].OutlineLevel!.Value);
+        Assert.Equal((byte)2, rows[7U].OutlineLevel!.Value);
+        Assert.Equal((byte)1, rows[9U].OutlineLevel!.Value);
+
+        Assert.Null(rows[2U].Hidden);
+        Assert.True(rows[4U].Hidden!.Value);
+        Assert.True(rows[5U].Hidden!.Value);
+        Assert.True(rows[6U].Hidden!.Value);
+        Assert.True(rows[7U].Hidden!.Value);
+
+        Assert.Null(rows[6U].Collapsed);
+        Assert.True(rows[7U].Collapsed!.Value);
+
+        AssertColumnState(worksheetPart.Worksheet, index: 1, level: 1, hidden: false, collapsed: false);
+        AssertColumnState(worksheetPart.Worksheet, index: 2, level: 2, hidden: true, collapsed: false);
+        AssertColumnState(worksheetPart.Worksheet, index: 3, level: 3, hidden: true, collapsed: false);
+        AssertColumnState(worksheetPart.Worksheet, index: 4, level: 3, hidden: true, collapsed: false);
+        AssertColumnState(worksheetPart.Worksheet, index: 5, level: 2, hidden: true, collapsed: true);
+        AssertColumnState(worksheetPart.Worksheet, index: 6, level: 1, hidden: false, collapsed: false);
+    }
+
+    /// <summary>
     /// Verifies that render formula ref placeholders are resolved before writing formula.
     /// </summary>
     [Fact]
@@ -525,6 +587,29 @@ public sealed class RendererTests
         Assert.Contains(sheets, sheet => sheet.Name == "Detail");
         Assert.Equal(2, result.SheetCount);
         Assert.Equal(3, result.CellCount);
+    }
+
+    private static void AssertColumnState(
+        Worksheet worksheet,
+        uint index,
+        byte level,
+        bool hidden,
+        bool collapsed)
+    {
+        var columns = worksheet.GetFirstChild<Columns>();
+        Assert.NotNull(columns);
+
+        var column = columns!
+            .Elements<Column>()
+            .Single(current =>
+                current.Min is not null &&
+                current.Max is not null &&
+                current.Min.Value <= index &&
+                current.Max.Value >= index);
+
+        Assert.Equal(level, column.OutlineLevel!.Value);
+        Assert.Equal(hidden, column.Hidden?.Value ?? false);
+        Assert.Equal(collapsed, column.Collapsed?.Value ?? false);
     }
 
     private static IRenderer CreateRenderer() => new XlsxRenderer();
@@ -681,3 +766,4 @@ public sealed class RendererTests
         return cell.CellValue?.Text ?? string.Empty;
     }
 }
+

--- a/ExcelReport/ExcelReportLib/Renderer/XlsxRenderer.cs
+++ b/ExcelReport/ExcelReportLib/Renderer/XlsxRenderer.cs
@@ -204,8 +204,7 @@ public sealed class XlsxRenderer : IRenderer
             return null;
         }
 
-        var columns = new Columns();
-
+        var ranges = new List<GroupRangeState>();
         foreach (var group in sheetState.Options.ColumnGroups)
         {
             if (!TryResolveColumnRange(sheetState, group.Target, out var start, out var end))
@@ -213,24 +212,57 @@ public sealed class XlsxRenderer : IRenderer
                 continue;
             }
 
-            columns.Append(
-                new Column
-                {
-                    Min = start,
-                    Max = end,
-                    OutlineLevel = 1,
-                    Hidden = group.Collapsed,
-                    Collapsed = group.Collapsed,
-                });
+            ranges.Add(new GroupRangeState(start, end, group.Collapsed));
         }
 
-        return columns.ChildElements.Count == 0 ? null : columns;
+        var outlineStates = BuildOutlineStates(ranges);
+        if (outlineStates.Count == 0)
+        {
+            return null;
+        }
+
+        var columns = new Columns();
+        var orderedStates = outlineStates
+            .OrderBy(entry => entry.Key)
+            .ToArray();
+
+        var segmentStart = orderedStates[0].Key;
+        var segmentEnd = orderedStates[0].Key;
+        var segmentState = orderedStates[0].Value;
+
+        for (var index = 1; index < orderedStates.Length; index++)
+        {
+            var current = orderedStates[index];
+            if (current.Key != segmentEnd + 1 || current.Value != segmentState)
+            {
+                columns.Append(CreateGroupedColumn(segmentStart, segmentEnd, segmentState));
+                segmentStart = current.Key;
+                segmentState = current.Value;
+            }
+
+            segmentEnd = current.Key;
+        }
+
+        columns.Append(CreateGroupedColumn(segmentStart, segmentEnd, segmentState));
+        return columns;
     }
+
+    private static Column CreateGroupedColumn(uint start, uint end, OutlineState state) =>
+        new()
+        {
+            Min = start,
+            Max = end,
+            OutlineLevel = state.OutlineLevel,
+            Hidden = state.Hidden ? true : null,
+            Collapsed = state.Collapsed ? true : null,
+        };
 
     private static void ApplyRowGroups(
         IDictionary<uint, Row> rowMap,
         IReadOnlyList<WorksheetGroupState> rowGroups)
     {
+        var ranges = new List<GroupRangeState>();
+
         foreach (var group in rowGroups)
         {
             if (!TryParseRowRange(group.Target, out var start, out var end))
@@ -238,22 +270,71 @@ public sealed class XlsxRenderer : IRenderer
                 continue;
             }
 
-            for (var rowIndex = start; rowIndex <= end; rowIndex++)
+            ranges.Add(new GroupRangeState(start, end, group.Collapsed));
+        }
+
+        var outlineStates = BuildOutlineStates(ranges);
+        foreach (var (rowIndex, state) in outlineStates.OrderBy(entry => entry.Key))
+        {
+            if (!rowMap.TryGetValue(rowIndex, out var row))
             {
-                if (!rowMap.TryGetValue(rowIndex, out var row))
+                row = new Row { RowIndex = rowIndex };
+                rowMap[rowIndex] = row;
+            }
+
+            row.OutlineLevel = state.OutlineLevel;
+            row.Hidden = state.Hidden ? true : null;
+            row.Collapsed = state.Collapsed ? true : null;
+        }
+    }
+
+    private static IReadOnlyDictionary<uint, OutlineState> BuildOutlineStates(
+        IReadOnlyList<GroupRangeState> groups)
+    {
+        if (groups.Count == 0)
+        {
+            return new Dictionary<uint, OutlineState>();
+        }
+
+        var depths = new Dictionary<uint, int>();
+        var hiddenIndexes = new HashSet<uint>();
+        var collapsedIndexes = new HashSet<uint>();
+
+        foreach (var group in groups)
+        {
+            for (var index = group.Start; index <= group.End; index++)
+            {
+                depths[index] = depths.TryGetValue(index, out var depth)
+                    ? depth + 1
+                    : 1;
+
+                if (group.Collapsed)
                 {
-                    row = new Row { RowIndex = rowIndex };
-                    rowMap[rowIndex] = row;
+                    hiddenIndexes.Add(index);
                 }
 
-                row.OutlineLevel = 1;
-                row.Hidden = group.Collapsed;
-                if (rowIndex == end)
+                if (index == group.End)
                 {
-                    row.Collapsed = group.Collapsed;
+                    break;
                 }
             }
+
+            if (group.Collapsed)
+            {
+                collapsedIndexes.Add(group.End);
+            }
         }
+
+        var states = new Dictionary<uint, OutlineState>(depths.Count);
+        foreach (var (index, depth) in depths)
+        {
+            states[index] = new OutlineState(
+                OutlineLevel: (byte)Math.Clamp(depth, 1, 8),
+                Hidden: hiddenIndexes.Contains(index),
+                Collapsed: collapsedIndexes.Contains(index));
+        }
+
+        return states;
     }
 
     private static Cell CreateCell(CellState cellState, StyleCatalog styleCatalog)
@@ -643,6 +724,10 @@ public sealed class XlsxRenderer : IRenderer
         return value;
     }
 
+    private readonly record struct GroupRangeState(uint Start, uint End, bool Collapsed);
+
+    private readonly record struct OutlineState(byte OutlineLevel, bool Hidden, bool Collapsed);
+
     private sealed class StyleCatalog
     {
         private readonly IReadOnlyDictionary<StyleKey, uint> _styleIndexes;
@@ -995,3 +1080,4 @@ public sealed class XlsxRenderer : IRenderer
             string? Color);
     }
 }
+

--- a/reports/group-nesting-auto-level-2026-03-07.md
+++ b/reports/group-nesting-auto-level-2026-03-07.md
@@ -1,0 +1,30 @@
+# Group Nesting Auto-Level 対応レポート (2026-03-07)
+
+## 概要
+- 要件: `sheetOptions/groups` の多段グループ化を、DSL拡張なしで対応する。
+- 方針: `groupRows` / `groupCols` の重なり数から OutlineLevel を自動算出する。
+
+## 設計更新
+- `Design/DslDefinition/DslDefinition_DetailDesign_v1.md` の 7.3 groups 節を更新。
+- 仕様:
+  - 対象範囲は従来通り `at` で解決した行/列範囲。
+  - 同一インデックスを覆うグループ数を OutlineLevel とする。
+  - OutlineLevel は Excel 上限に合わせ `1..8` に丸める。
+  - `collapsed=true` の場合、対象行/列を Hidden にし、終端インデックスに Collapsed を設定する。
+
+## 実装変更
+- `ExcelReport/ExcelReportLib/Renderer/XlsxRenderer.cs`
+  - 行/列グループ処理を固定レベル `1` から自動算出ロジックへ変更。
+  - 追加: `BuildOutlineStates(...)` で深さ・Hidden・Collapsed を計算。
+  - 列は連続セグメントごとに `Column` を集約出力。
+
+## テスト
+- 追加: `Render_NestedGroups_OutlineLevelsAreAutoCalculated`
+  - 行: 3段ネストの OutlineLevel / Hidden / Collapsed を検証。
+  - 列: 3段ネストの OutlineLevel / Hidden / Collapsed を検証。
+- 実行:
+  - `dotnet test --filter "RendererTests|WorksheetStateTests"`
+  - 結果: 26 passed, 0 failed
+
+## 補足
+- 既存の nullable warning は今回スコープ外（新規エラーなし）。


### PR DESCRIPTION
## Summary
- auto-calculate outline levels from overlapping row/column group ranges
- apply hidden/collapsed flags based on collapsed group ranges
- add renderer test for nested row/column groups
- update DSL design doc and add implementation report

## Test
- Added unit test: Render_NestedGroups_OutlineLevelsAreAutoCalculated
