### PR TITLE
Show prereleases on GitHub Releases and remove run suffix

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     env:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
@@ -43,7 +43,7 @@ jobs:
               if [[ "$base_version" == *-* ]]; then
                 package_version="$base_version"
               else
-                package_version="${base_version}-pre.${GITHUB_RUN_NUMBER}"
+                package_version="${base_version}-pre"
               fi
             else
               if [[ "$base_version" == *-* ]]; then
@@ -73,7 +73,7 @@ jobs:
             fi
 
             next_patch=$((patch + commits_since_base))
-            package_version="${major}.${minor}.${next_patch}-pre.${GITHUB_RUN_NUMBER}"
+            package_version="${major}.${minor}.${next_patch}-pre"
           else
             package_version="${version_prefix}-ci.${GITHUB_RUN_NUMBER}"
           fi
@@ -114,4 +114,22 @@ jobs:
             --api-key "${{ env.NUGET_API_KEY }}" \
             --source "https://api.nuget.org/v3/index.json" \
             --skip-duplicate
+      - name: Create GitHub Pre-release
+        if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          tag="${{ steps.version.outputs.package_version }}"
+          if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "GitHub pre-release already exists: $tag"
+            exit 0
+          fi
+
+          gh release create "$tag" \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            --title "$tag" \
+            --notes "Automated pre-release from master push." \
+            --prerelease
 

--- a/reports/master-push-prerelease-auto-version-2026-03-24.md
+++ b/reports/master-push-prerelease-auto-version-2026-03-24.md
@@ -1,25 +1,27 @@
-# master push時のNuGet prerelease自動採番対応 (2026-03-24)
+# master push時のNuGet/GitHub pre-release自動化対応 (2026-03-24)
 
 ## 要件
 - `master` へ push されたとき、NuGet package を自動で prerelease 発行する。
+- GitHub の「Releases」画面にも pre-release を自動表示する。
 - バージョンは 3 桁目（patch）を自動増分する。
+- prerelease suffix は `-pre` 固定とし、`-pre.<run_number>` は付与しない。
 - 通常 release（正式版）は手動運用を継続する。
 
 ## 変更内容
 - `.github/workflows/publish-nuget.yml`
-  - トリガーに `push: [master]` を追加。
-  - `actions/checkout` を `fetch-depth: 0` に変更（タグ参照のため）。
-  - バージョン解決ロジックを拡張:
-    - release イベント: 既存どおりタグ基準で version を決定。
-    - master push イベント: 最新安定タグ `X.Y.Z` を基準に `patch + commits_since_tag` を算出し、`X.Y.<next>-pre.<run_number>` を採用。
+  - トリガーに `push: [master]` を追加済み。
+  - `actions/checkout` を `fetch-depth: 0` に変更済み（タグ参照のため）。
+  - `permissions.contents` を `write` に変更（GitHub Release 作成のため）。
+  - バージョン解決ロジック:
+    - release イベント: 手動 release の tag を基準に version を決定。
+    - master push イベント: 最新安定タグ `X.Y.Z` を基準に `patch + commits_since_tag` を算出し、`X.Y.<next>-pre` を採用。
     - タグ未存在時は `VersionPrefix` を基準に同様に算出。
+  - master push 時に `gh release create --prerelease` を実行し、GitHub pre-release を自動作成。
+  - 同一 tag が既に存在する場合は作成をスキップ。
 
 ## 期待動作
 - 例: 最新安定タグが `1.1.0` のとき
-  - タグ以降1コミット目の master push -> `1.1.1-pre.<run>`
-  - タグ以降2コミット目の master push -> `1.1.2-pre.<run>`
+  - タグ以降1コミット目の master push -> `1.1.1-pre`
+  - タグ以降2コミット目の master push -> `1.1.2-pre`
+- 各 master push ごとに NuGet prerelease が publish され、同名 tag の GitHub pre-release が作成される。
 - 手動 release (`release.published`) は従来どおり正式版/指定済みprereleaseを発行。
-
-## 補足
-- 同一コミットで再実行されても `-pre.<run_number>` で一意性を確保。
-

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -43,6 +43,7 @@ Last Updated: 2026-03-24
 | FP49 | master push時はNuGet prereleaseを自動発行し、patch(3桁目)は自動増分する。通常releaseは手動運用を継続する | 対応中 | 2026-03-24 |
 | FP50 | from/var は属性と要素の両記法を許容し、競合時は属性優先 + Warning記録で継続処理する | 対応中 | 2026-03-24 |
 | FP51 | 既存の設計書（DslDefinition/DslParser）にも from/var 属性・子要素併用仕様を反映する | 対応済み | 2026-03-24 |
+| FP52 | GitHub の Releases 画面に pre-release を表示できるよう、master push で pre-release を自動作成する | 対応中 | 2026-03-24 |
 ---
 
 ## 対応履歴

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -4,6 +4,9 @@ Last Updated: 2026-03-24
 
 ## Overall Progress
 
+- 2026-03-24: master push時のprerelease suffixを `-pre` 固定へ変更（`-pre.<run_number>` を廃止）
+- 2026-03-24: master push時に GitHub pre-release を自動作成する処理を publish workflow に追加
+- 2026-03-24: 調査記録 `reports/master-push-prerelease-auto-version-2026-03-24.md` を NuGet/GitHub 両対応内容へ更新
 - 2026-03-24: `sheet` / `repeat` の from/var の子要素指定を追加し、属性形式との後方互換を維持
 - 2026-03-24: 属性と子要素の同時指定時に Warning を記録し、属性値を優先する排他ルールを実装
 - 2026-03-24: 設計書 `Design/DslDefinition/DslDefinition_DetailDesign_v1.md` / `Design/DslParser/DslParser_DetailDesign_v1.md` を実装仕様に同期

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -5,6 +5,9 @@ Scope: ExcelReport開発 - Phase 10: sheet repeat対応
 
 ## Progress Summary
 
+- 2026-03-24 CI改善: master push時のNuGet prerelease suffixを `-pre` 固定へ変更（`-pre.<run_number>` 廃止）
+- 2026-03-24 CI改善: master push時に GitHub pre-release も自動作成する処理を追加
+- 2026-03-24 記録更新: `reports/master-push-prerelease-auto-version-2026-03-24.md` をNuGet/GitHub両対応内容へ更新
 - 2026-03-24 機能追加: `sheet` / `repeat` の `from`・`var` で子要素指定をサポート（属性形式も継続サポート）
 - 2026-03-24 互換制御: 属性と子要素が同時指定された場合はIssue(Warning)を記録し、属性値を優先
 - 2026-03-24 設計更新: `Design/DslDefinition/DslDefinition_DetailDesign_v1.md` と `Design/DslParser/DslParser_DetailDesign_v1.md` に from/var の属性・子要素併用仕様を反映


### PR DESCRIPTION
## Summary
- change master-push prerelease version from -pre.<run_number> to -pre
- keep patch auto-increment logic, so each master commit still gets a unique prerelease version
- add automatic GitHub pre-release creation on master push (gh release create --prerelease)
- skip creation if the same release tag already exists
- update report/tasks tracking docs accordingly

## Result
- NuGet prerelease example: 1.1.1-pre
- GitHub Releases page now gets a corresponding pre-release entry for master-push builds