### PR TITLE
Fix nested repeat conditional var expression rewrite

### DIFF
--- a/ExcelReport/ExcelReportLib.Tests/LayoutEngineTests.cs
+++ b/ExcelReport/ExcelReportLib.Tests/LayoutEngineTests.cs
@@ -405,6 +405,65 @@ public sealed class LayoutEngineTests
     }
 
     /// <summary>
+    /// Verifies that nested repeat var references in a conditional expression are fully rewritten.
+    /// </summary>
+    [Fact]
+    public void Expand_NestedRepeat_ConditionalExpressionUsingVarMultipleTimes_DoesNotEmitExpressionSyntaxError()
+    {
+        var root = new CompareRoot
+        {
+            Pairs =
+            [
+                new ComparePair
+                {
+                    Key = "L1",
+                    Mchs =
+                    [
+                        new Mch { Name = "Machine1" },
+                        new Mch { Name = "Machine2" },
+                    ],
+                },
+                new ComparePair
+                {
+                    Key = "L2",
+                    Mchs =
+                    [
+                        new Mch { Name = "Machine3" },
+                        new Mch { Name = "Machine4" },
+                    ],
+                },
+            ],
+        };
+
+        var plan = Expand(
+            """
+            <workbook xmlns="urn:excelreport:v1">
+              <sheet name="Compare">
+                <repeat r="1" c="1" direction="down" from="@(root.Pairs)" var="p">
+                  <grid>
+                    <cell r="1" c="1" value="@(p.Key)" />
+                    <repeat r="1" c="2" direction="right" from="@(p.Mchs)" var="m">
+                      <cell r="1" c="1" value="@(m.Name != &quot;Machine1&quot; ? m.Name : &quot;&quot;)" />
+                    </repeat>
+                  </grid>
+                </repeat>
+              </sheet>
+            </workbook>
+            """,
+            root);
+
+        Assert.DoesNotContain(plan.Issues, issue => issue.Kind == IssueKind.ExpressionSyntaxError);
+
+        var values = Assert.Single(plan.Sheets).Cells.Select(cell => cell.Value?.ToString()).ToArray();
+        Assert.Contains("L1", values);
+        Assert.Contains("L2", values);
+        Assert.Contains(string.Empty, values);
+        Assert.Contains("Machine2", values);
+        Assert.Contains("Machine3", values);
+        Assert.Contains("Machine4", values);
+    }
+
+    /// <summary>
     /// Verifies that expand grid border mode all applied to all cells.
     /// </summary>
     [Fact]
@@ -756,6 +815,23 @@ public sealed class LayoutEngineTests
     private sealed class NestedGridRoot
     {
         public List<GridRow> Rows { get; init; } = [];
+    }
+
+    private sealed class CompareRoot
+    {
+        public List<ComparePair> Pairs { get; init; } = [];
+    }
+
+    private sealed class ComparePair
+    {
+        public string Key { get; init; } = string.Empty;
+
+        public List<Mch> Mchs { get; init; } = [];
+    }
+
+    private sealed class Mch
+    {
+        public string? Name { get; init; }
     }
 
     private sealed class RepeatItem

--- a/ExcelReport/ExcelReportLib/LayoutEngine/LayoutEngine.cs
+++ b/ExcelReport/ExcelReportLib/LayoutEngine/LayoutEngine.cs
@@ -5,6 +5,9 @@ using ExcelReportLib.DSL.AST;
 using ExcelReportLib.DSL.AST.LayoutNode;
 using ExcelReportLib.ExpressionEngine;
 using ExcelReportLib.Styles;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ExcelReportLib.LayoutEngine;
 
@@ -801,24 +804,96 @@ public sealed class LayoutEngine : ILayoutEngine
         foreach (var pair in vars)
         {
             var variableName = pair.Key;
-            if (body.StartsWith(variableName + ".", StringComparison.Ordinal))
+            var isScoped = body.StartsWith(variableName + ".", StringComparison.Ordinal)
+                || body.StartsWith(variableName + "[", StringComparison.Ordinal);
+            if (!isScoped)
             {
-                rewrittenExpression = "@(data." + body[(variableName.Length + 1)..] + ")";
-                scopedData = pair.Value;
-                return true;
+                continue;
             }
 
-            if (body.StartsWith(variableName + "[", StringComparison.Ordinal))
+            if (TryRewriteScopedVariableExpressionBody(body, variableName, out var rewrittenBody))
+            {
+                rewrittenExpression = "@(" + rewrittenBody + ")";
+            }
+            else if (body.StartsWith(variableName + ".", StringComparison.Ordinal))
+            {
+                rewrittenExpression = "@(data." + body[(variableName.Length + 1)..] + ")";
+            }
+            else
             {
                 rewrittenExpression = "@(data" + body[variableName.Length..] + ")";
-                scopedData = pair.Value;
-                return true;
             }
+
+            scopedData = pair.Value;
+            return true;
         }
 
         rewrittenExpression = string.Empty;
         scopedData = null;
         return false;
+    }
+
+    private static bool TryRewriteScopedVariableExpressionBody(
+        string expressionBody,
+        string variableName,
+        out string rewrittenBody)
+    {
+        var syntax = SyntaxFactory.ParseExpression(expressionBody);
+        if (syntax.ContainsDiagnostics)
+        {
+            rewrittenBody = string.Empty;
+            return false;
+        }
+
+        var rewriter = new ScopedVariableExpressionRewriter(variableName);
+        if (rewriter.Visit(syntax) is not ExpressionSyntax rewrittenSyntax)
+        {
+            rewrittenBody = string.Empty;
+            return false;
+        }
+
+        rewrittenBody = rewriter.Rewritten
+            ? rewrittenSyntax.ToFullString()
+            : expressionBody;
+        return true;
+    }
+
+    private sealed class ScopedVariableExpressionRewriter : CSharpSyntaxRewriter
+    {
+        private readonly string _variableName;
+
+        public ScopedVariableExpressionRewriter(string variableName)
+        {
+            _variableName = variableName;
+        }
+
+        public bool Rewritten { get; private set; }
+
+        public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+        {
+            var visited = (MemberAccessExpressionSyntax)base.VisitMemberAccessExpression(node)!;
+            if (visited.Expression is IdentifierNameSyntax identifier
+                && string.Equals(identifier.Identifier.ValueText, _variableName, StringComparison.Ordinal))
+            {
+                Rewritten = true;
+                return visited.WithExpression(SyntaxFactory.IdentifierName("data"));
+            }
+
+            return visited;
+        }
+
+        public override SyntaxNode? VisitElementAccessExpression(ElementAccessExpressionSyntax node)
+        {
+            var visited = (ElementAccessExpressionSyntax)base.VisitElementAccessExpression(node)!;
+            if (visited.Expression is IdentifierNameSyntax identifier
+                && string.Equals(identifier.Identifier.ValueText, _variableName, StringComparison.Ordinal))
+            {
+                Rewritten = true;
+                return visited.WithExpression(SyntaxFactory.IdentifierName("data"));
+            }
+
+            return visited;
+        }
     }
 
     private static string NormalizeExpressionBody(string expression)

--- a/reports/repeat-var-conditional-expression-fix-2026-03-24.md
+++ b/reports/repeat-var-conditional-expression-fix-2026-03-24.md
@@ -1,0 +1,21 @@
+# repeat var 条件式不具合 修正レポート (2026-03-24)
+
+## 事象
+- テンプレート内で入れ子 `repeat` の `var` を条件式で複数回参照すると、`ExpressionSyntaxError` が発生。
+- 例: `@(m.Name != "Machine1" ? m.Name : "")`
+- 発生エラー: `CS0103: 現在のコンテキストに 'm' という名前は存在しません`
+
+## 原因
+- `LayoutEngine.TryRewriteVariableScopedExpression` が、`m.` 先頭1箇所だけを `data.` へ置換していた。
+- そのため上記式は `data.Name != "Machine1" ? m.Name : ""` となり、後半の `m.Name` が未解決になっていた。
+
+## 対応
+- `LayoutEngine` に Roslyn ベースの式書き換えを追加。
+- 先頭一致した `var`（例: `m`）について、式中の `m.` / `m[...]` 参照を構文木上で `data.` / `data[...]` に一括置換。
+- 解析不能時は既存の先頭置換フォールバックを維持。
+
+## テスト
+- 追加: `LayoutEngineTests.Expand_NestedRepeat_ConditionalExpressionUsingVarMultipleTimes_DoesNotEmitExpressionSyntaxError`
+- 修正前: 失敗（`ExpressionSyntaxError` を4件検出）
+- 修正後: 成功
+- 追加確認: `LayoutEngineTests` 全体（19件）成功

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -45,6 +45,7 @@ Last Updated: 2026-03-24
 | FP51 | 既存の設計書（DslDefinition/DslParser）にも from/var 属性・子要素併用仕様を反映する | 対応済み | 2026-03-24 |
 | FP52 | GitHub の Releases 画面に pre-release を表示できるよう、master push で pre-release を自動作成する | 対応中 | 2026-03-24 |
 | FP53 | NuGet READMEはリポジトリREADMEへ一本化し、二重管理を避ける。buildステータス表示は実ワークフローバッジに合わせる | 対応済み | 2026-03-24 |
+| FP54 | 入れ子repeatの条件式でvarを複数回参照した際のExpressionSyntaxError（m未解決）を解消する | 対応済み | 2026-03-24 |
 ---
 
 ## 対応履歴

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -4,6 +4,9 @@ Last Updated: 2026-03-24
 
 ## Overall Progress
 
+- 2026-03-24: 入れ子repeat条件式 (`m.Name != "Machine1" ? m.Name : ""`) で `m` が未解決になる不具合を修正
+- 2026-03-24: `LayoutEngine` の var スコープ式書き換えをRoslyn構文木ベースへ拡張し、式中の複数参照を一括置換
+- 2026-03-24: 調査記録 `reports/repeat-var-conditional-expression-fix-2026-03-24.md` を追加
 - 2026-03-24: ルートREADMEのbuildステータスバッジを実ワークフロー表示へ修正
 - 2026-03-24: NuGet同梱READMEをリポジトリREADMEへ一本化し、専用READMEを削除
 - 2026-03-24: 調査記録 `reports/readme-badge-and-package-readme-sync-2026-03-24.md` を追加

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -5,6 +5,9 @@ Scope: ExcelReport開発 - Phase 10: sheet repeat対応
 
 ## Progress Summary
 
+- 2026-03-24 不具合修正: 入れ子repeatの条件式で var を複数参照した際の ExpressionSyntaxError (m 未解決) を解消
+- 2026-03-24 テスト追加: LayoutEngineTests.Expand_NestedRepeat_ConditionalExpressionUsingVarMultipleTimes_DoesNotEmitExpressionSyntaxError を追加（修正前Fail/修正後Pass）
+- 2026-03-24 記録: `reports/repeat-var-conditional-expression-fix-2026-03-24.md` を作成
 - 2026-03-24 ドキュメント改善: ルートREADMEのbuildステータスバッジを実ワークフロー表示へ修正
 - 2026-03-24 運用統一: NuGet同梱READMEをリポジトリREADMEへ一本化（専用README削除）
 - 2026-03-24 記録: `reports/readme-badge-and-package-readme-sync-2026-03-24.md` を作成


### PR DESCRIPTION
## 概要
- 入れ子repeatの条件式で m を複数回参照すると ExpressionSyntaxError (CS0103) になる不具合を修正
- LayoutEngine.TryRewriteVariableScopedExpression を拡張し、先頭1箇所だけでなく式全体の m. / m[...] 参照をRoslyn構文木で data. / data[...] に置換
- 再現テストを追加（修正前Fail/修正後Pass）

## 追加テスト
- LayoutEngineTests.Expand_NestedRepeat_ConditionalExpressionUsingVarMultipleTimes_DoesNotEmitExpressionSyntaxError
- LayoutEngineTests 全体（19件）

## 備考
- reports/tasks/feedback を更新済み