### PR TITLE
Fix repeat var rewrite for parenthesized expressions

### DIFF
--- a/ExcelReport/ExcelReportLib.Tests/LayoutEngineTests.cs
+++ b/ExcelReport/ExcelReportLib.Tests/LayoutEngineTests.cs
@@ -464,6 +464,76 @@ public sealed class LayoutEngineTests
     }
 
     /// <summary>
+    /// Verifies that repeat var references wrapped by parentheses do not emit expression syntax error.
+    /// </summary>
+    [Fact]
+    public void Expand_RepeatVarExpressionWrappedWithParentheses_DoesNotEmitExpressionSyntaxError()
+    {
+        var root = new CompareRoot
+        {
+            Pairs =
+            [
+                new ComparePair { LeftBoard = "L1", RightBoard = "R1" },
+                new ComparePair { LeftBoard = null, RightBoard = "R2" },
+            ],
+        };
+
+        var plan = Expand(
+            """
+            <workbook xmlns="urn:excelreport:v1">
+              <sheet name="Compare">
+                <repeat r="1" c="1" direction="down" from="@(root.Pairs)" var="p">
+                  <cell r="1" c="12" value="@((p.LeftBoard ?? &quot;&quot;) + &quot;/&quot; + (p.RightBoard ?? &quot;&quot;))" />
+                </repeat>
+              </sheet>
+            </workbook>
+            """,
+            root);
+
+        Assert.DoesNotContain(plan.Issues, issue => issue.Kind == IssueKind.ExpressionSyntaxError);
+
+        var cells = Assert.Single(plan.Sheets).Cells;
+        Assert.Equal(2, cells.Count);
+        Assert.Equal("L1/R1", cells[0].Value);
+        Assert.Equal("/R2", cells[1].Value);
+    }
+
+    /// <summary>
+    /// Verifies that repeat var identifier references are rewritten in any expression position.
+    /// </summary>
+    [Fact]
+    public void Expand_RepeatVarIdentifierReferenceInConditional_DoesNotEmitExpressionSyntaxError()
+    {
+        var root = new CompareRoot
+        {
+            Pairs =
+            [
+                new ComparePair { LeftBoard = "L1", RightBoard = "R1" },
+                new ComparePair { LeftBoard = null, RightBoard = "R2" },
+            ],
+        };
+
+        var plan = Expand(
+            """
+            <workbook xmlns="urn:excelreport:v1">
+              <sheet name="Compare">
+                <repeat r="1" c="1" direction="down" from="@(root.Pairs)" var="p">
+                  <cell r="1" c="12" value="@(p == null ? &quot;NA&quot; : ((p.LeftBoard ?? &quot;&quot;) + &quot;/&quot; + (p.RightBoard ?? &quot;&quot;)))" />
+                </repeat>
+              </sheet>
+            </workbook>
+            """,
+            root);
+
+        Assert.DoesNotContain(plan.Issues, issue => issue.Kind == IssueKind.ExpressionSyntaxError);
+
+        var cells = Assert.Single(plan.Sheets).Cells;
+        Assert.Equal(2, cells.Count);
+        Assert.Equal("L1/R1", cells[0].Value);
+        Assert.Equal("/R2", cells[1].Value);
+    }
+
+    /// <summary>
     /// Verifies that expand grid border mode all applied to all cells.
     /// </summary>
     [Fact]
@@ -825,6 +895,10 @@ public sealed class LayoutEngineTests
     private sealed class ComparePair
     {
         public string Key { get; init; } = string.Empty;
+
+        public string? LeftBoard { get; init; }
+
+        public string? RightBoard { get; init; }
 
         public List<Mch> Mchs { get; init; } = [];
     }

--- a/ExcelReport/ExcelReportLib/LayoutEngine/LayoutEngine.cs
+++ b/ExcelReport/ExcelReportLib/LayoutEngine/LayoutEngine.cs
@@ -804,28 +804,35 @@ public sealed class LayoutEngine : ILayoutEngine
         foreach (var pair in vars)
         {
             var variableName = pair.Key;
-            var isScoped = body.StartsWith(variableName + ".", StringComparison.Ordinal)
-                || body.StartsWith(variableName + "[", StringComparison.Ordinal);
-            if (!isScoped)
+            if (TryRewriteScopedVariableExpressionBody(
+                body,
+                variableName,
+                out var rewrittenBody,
+                out var wasRewritten))
             {
-                continue;
+                if (!wasRewritten)
+                {
+                    continue;
+                }
+
+                rewrittenExpression = "@(" + rewrittenBody + ")";
+                scopedData = pair.Value;
+                return true;
             }
 
-            if (TryRewriteScopedVariableExpressionBody(body, variableName, out var rewrittenBody))
-            {
-                rewrittenExpression = "@(" + rewrittenBody + ")";
-            }
-            else if (body.StartsWith(variableName + ".", StringComparison.Ordinal))
+            if (body.StartsWith(variableName + ".", StringComparison.Ordinal))
             {
                 rewrittenExpression = "@(data." + body[(variableName.Length + 1)..] + ")";
-            }
-            else
-            {
-                rewrittenExpression = "@(data" + body[variableName.Length..] + ")";
+                scopedData = pair.Value;
+                return true;
             }
 
-            scopedData = pair.Value;
-            return true;
+            if (body.StartsWith(variableName + "[", StringComparison.Ordinal))
+            {
+                rewrittenExpression = "@(data" + body[variableName.Length..] + ")";
+                scopedData = pair.Value;
+                return true;
+            }
         }
 
         rewrittenExpression = string.Empty;
@@ -836,12 +843,14 @@ public sealed class LayoutEngine : ILayoutEngine
     private static bool TryRewriteScopedVariableExpressionBody(
         string expressionBody,
         string variableName,
-        out string rewrittenBody)
+        out string rewrittenBody,
+        out bool wasRewritten)
     {
         var syntax = SyntaxFactory.ParseExpression(expressionBody);
         if (syntax.ContainsDiagnostics)
         {
             rewrittenBody = string.Empty;
+            wasRewritten = false;
             return false;
         }
 
@@ -849,12 +858,12 @@ public sealed class LayoutEngine : ILayoutEngine
         if (rewriter.Visit(syntax) is not ExpressionSyntax rewrittenSyntax)
         {
             rewrittenBody = string.Empty;
+            wasRewritten = false;
             return false;
         }
 
-        rewrittenBody = rewriter.Rewritten
-            ? rewrittenSyntax.ToFullString()
-            : expressionBody;
+        wasRewritten = rewriter.Rewritten;
+        rewrittenBody = wasRewritten ? rewrittenSyntax.ToFullString() : expressionBody;
         return true;
     }
 
@@ -868,6 +877,18 @@ public sealed class LayoutEngine : ILayoutEngine
         }
 
         public bool Rewritten { get; private set; }
+
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (string.Equals(node.Identifier.ValueText, _variableName, StringComparison.Ordinal)
+                && !IsIdentifierInMemberNamePosition(node))
+            {
+                Rewritten = true;
+                return SyntaxFactory.IdentifierName("data").WithTriviaFrom(node);
+            }
+
+            return base.VisitIdentifierName(node);
+        }
 
         public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
         {
@@ -893,6 +914,23 @@ public sealed class LayoutEngine : ILayoutEngine
             }
 
             return visited;
+        }
+
+        private static bool IsIdentifierInMemberNamePosition(IdentifierNameSyntax node)
+        {
+            if (node.Parent is MemberAccessExpressionSyntax memberAccess
+                && ReferenceEquals(memberAccess.Name, node))
+            {
+                return true;
+            }
+
+            if (node.Parent is QualifiedNameSyntax qualifiedName
+                && ReferenceEquals(qualifiedName.Right, node))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 
@@ -1287,3 +1325,4 @@ public sealed class LayoutEngine : ILayoutEngine
         }
     }
 }
+

--- a/reports/rewrite-repeat-var-robust-2026-03-24.md
+++ b/reports/rewrite-repeat-var-robust-2026-03-24.md
@@ -1,0 +1,31 @@
+# repeat var rewrite robust化 対応記録 (2026-03-24)
+
+## 背景
+- 1.2.2-pre で epeat 内の式が @((p.LeftBoard ?? "") + "/" + (p.RightBoard ?? "")) のように括弧で始まる場合、p が未定義として ExpressionSyntaxError になる。
+- 原因は LayoutEngine の var 書き換えが「式先頭が p. / p[」という条件に依存していたため。
+
+## 根本原因
+- TryRewriteVariableScopedExpression が先頭一致判定で書き換え対象を絞り込み、式中参照（先頭以外）を取りこぼしていた。
+- ScopedVariableExpressionRewriter が MemberAccess / ElementAccess のみ対応で、p == null のような識別子参照は未対応だった。
+
+## 対応内容
+1. TryRewriteVariableScopedExpression の判定を先頭一致前提から変更。
+   - 各 var 名に対して式全体を Roslyn で解析し、実際に書き換えが発生したときだけ採用。
+2. TryRewriteScopedVariableExpressionBody を拡張。
+   - wasRewritten を返し、解析成功と実際の置換有無を分離。
+3. ScopedVariableExpressionRewriter を拡張。
+   - VisitIdentifierName を追加し、p == null など識別子参照も data へ置換。
+   - ただし oo.p の p のようなメンバー名位置は置換しない。
+
+## テスト
+- 追加: Expand_RepeatVarExpressionWrappedWithParentheses_DoesNotEmitExpressionSyntaxError
+  - 再現ケースを固定化（修正前 Fail / 修正後 Pass）。
+- 追加: Expand_RepeatVarIdentifierReferenceInConditional_DoesNotEmitExpressionSyntaxError
+  - p == null を含む条件式で識別子参照の書き換えを確認。
+- 実行:
+  - dotnet test ExcelReport/ExcelReportLib.Tests/ExcelReportLib.Tests.csproj --no-restore --filter "FullyQualifiedName~LayoutEngineTests"
+  - 結果: 21/21 Passed。
+
+## 影響範囲
+- LayoutEngine の repeat var 書き換え経路のみ。
+- 既存の p.Member / p[index] の動作互換は維持。

--- a/tasks/feedback-points.md
+++ b/tasks/feedback-points.md
@@ -46,6 +46,7 @@ Last Updated: 2026-03-24
 | FP52 | GitHub の Releases 画面に pre-release を表示できるよう、master push で pre-release を自動作成する | 対応中 | 2026-03-24 |
 | FP53 | NuGet READMEはリポジトリREADMEへ一本化し、二重管理を避ける。buildステータス表示は実ワークフローバッジに合わせる | 対応済み | 2026-03-24 |
 | FP54 | 入れ子repeatの条件式でvarを複数回参照した際のExpressionSyntaxError（m未解決）を解消する | 対応済み | 2026-03-24 |
+| FP55 | rewrite処理はモグラたたきではなく汎用的な方式（先頭一致依存を排除）で修正する | 対応済み | 2026-03-24 |
 ---
 
 ## 対応履歴
@@ -67,4 +68,6 @@ Last Updated: 2026-03-24
 | FP11 | PM/Codex責任分担の明確化 | 2026-03-03 |
 | FP12 | git commit -a で許可削減 | 2026-03-03 |
 | FP13 | 毎回の許可確認を排除 | 2026-03-03 |
+
+
 

--- a/tasks/phases-status.md
+++ b/tasks/phases-status.md
@@ -4,6 +4,9 @@ Last Updated: 2026-03-24
 
 ## Overall Progress
 
+- 2026-03-24: repeat内の括弧付き式（@((p...))）で var 未解決となる不具合を修正
+- 2026-03-24: var書き換えを先頭一致判定から式全体のRoslyn構文木置換へ一般化
+- 2026-03-24: 調査記録 reports/rewrite-repeat-var-robust-2026-03-24.md を追加
 - 2026-03-24: 入れ子repeat条件式 (`m.Name != "Machine1" ? m.Name : ""`) で `m` が未解決になる不具合を修正
 - 2026-03-24: `LayoutEngine` の var スコープ式書き換えをRoslyn構文木ベースへ拡張し、式中の複数参照を一括置換
 - 2026-03-24: 調査記録 `reports/repeat-var-conditional-expression-fix-2026-03-24.md` を追加
@@ -63,3 +66,6 @@ Last Updated: 2026-03-24
 - Not Started: 未着手
 - In Progress: 実施中
 - Completed: 完了
+
+
+

--- a/tasks/tasks-status.md
+++ b/tasks/tasks-status.md
@@ -5,6 +5,10 @@ Scope: ExcelReport開発 - Phase 10: sheet repeat対応
 
 ## Progress Summary
 
+- 2026-03-24 不具合修正: repeat内の括弧付き式（@((p...))）で var が未解決になる ExpressionSyntaxError を解消
+- 2026-03-24 実装改善: var書き換えを先頭一致依存からRoslyn構文木ベースの実参照置換へ一般化
+- 2026-03-24 テスト追加: LayoutEngineTests に括弧付き式ケースと識別子参照ケース（p == null）を追加
+- 2026-03-24 記録: reports/rewrite-repeat-var-robust-2026-03-24.md を作成
 - 2026-03-24 不具合修正: 入れ子repeatの条件式で var を複数参照した際の ExpressionSyntaxError (m 未解決) を解消
 - 2026-03-24 テスト追加: LayoutEngineTests.Expand_NestedRepeat_ConditionalExpressionUsingVarMultipleTimes_DoesNotEmitExpressionSyntaxError を追加（修正前Fail/修正後Pass）
 - 2026-03-24 記録: `reports/repeat-var-conditional-expression-fix-2026-03-24.md` を作成
@@ -101,3 +105,6 @@ Scope: ExcelReport開発 - Phase 10: sheet repeat対応
 - Done: 完了
 - In Progress: 実施中
 - Not Started: 未着手
+
+
+


### PR DESCRIPTION
## Summary
- fix repeat var rewrite so expressions are rewritten based on full Roslyn syntax traversal, not only prefix checks
- support identifier references like p == null in scoped rewrite while avoiding member-name position rewrites
- add regression tests for parenthesized repeat expressions and identifier-conditional expressions

## Verification
- dotnet test ExcelReport/ExcelReportLib.Tests/ExcelReportLib.Tests.csproj --no-restore --filter "FullyQualifiedName~LayoutEngineTests"
